### PR TITLE
Stable scrollbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
 }>) {
   return (
     <ViewTransitions>
-      <html lang="en" className={inter.className}>
+      <html lang="en" className={`${inter.className} [scrollbar-gutter:stable]`}>
         <body className="antialiased tracking-tight">
           <div className="min-h-screen flex flex-col justify-between pt-0 md:pt-8 p-8 bg-white text-gray-900">
             <main className="max-w-[60ch] mx-auto w-full space-y-6">


### PR DESCRIPTION
The view transition with your name looks a bit weird when a scrollbar appears, because the content is shifted slightly. Fixed by setting [`scrollbar-gutter`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) to `stable`.

Awesome redesign, love the simplicity!