### PR TITLE
Delete unused Link declaration

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,5 +1,4 @@
 import React, { ComponentPropsWithoutRef } from 'react';
-import Link from 'next/link';
 import { highlight } from 'sugar-high';
 
 type HeadingProps = ComponentPropsWithoutRef<'h1'>;


### PR DESCRIPTION
‘Link’ is declared but its value is never read 